### PR TITLE
bug(api): fix blank API falling through to authorized

### DIFF
--- a/slack-uploader/web_receiver.go
+++ b/slack-uploader/web_receiver.go
@@ -38,6 +38,7 @@ func uploadAuthorization(c *gin.Context) error {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		c.Error(fmt.Errorf("Unauthorized request from IP: %s", c.ClientIP()))
 		log.Warnln("Request has invalid API key")
+		err = fmt.Errorf("Invalid API Key")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Previously bad API keys were rejected, but blank fell through -- even though
they gave an unauthorized message. This fixes a logic error to ensure items are
failing secure.

Fixes #2