### PR TITLE
This adds a /usage endpoint for documentation and improves the documentation sent via the application to a user requesting a new API key.

### DIFF
--- a/cspp/go.mod
+++ b/cspp/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.4.0
+	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.12.3
 	github.com/spf13/pflag v1.0.5

--- a/cspp/go.sum
+++ b/cspp/go.sum
@@ -63,6 +63,8 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=

--- a/cspp/slack_sender.go
+++ b/cspp/slack_sender.go
@@ -88,9 +88,19 @@ func sendKeyInDM(slackId string, key string) error {
 	log.Debugln("(sendKeyInDM) slackId", slackId, "key", key)
 	slack_token := viper.GetString("slack_token")
 	api := slack.New(slack_token)
+	msg := "Your CSPP API key is:  `" + key + "`" + ". Please keep it safe and do not share it with anyone. "
+	msg += "In most cases, you can use your key and the entire CSPP service via something like the following command:\n"
+	cmd := `curl -X POST \
+  -F "image=@/path/to/file" \
+  -F "caption=String you want to with the picture"  \
+  -H "X-API-KEY: $API_KEY" \
+ <service URI>"`
+	msg += "```" + cmd + "```"
+	// TODO add the service URI to the message
+	msg += "\n See /usage for more details."
 
 	_, _, err := api.PostMessage(slackId,
-		slack.MsgOptionText(key, false),
+		slack.MsgOptionText(msg, false),
 		slack.MsgOptionAsUser(true),
 	)
 	if err != nil {


### PR DESCRIPTION
There will still be some follow-on as we need to plumb through CSPP_BASE_URL to
ensure we can populate clickable links.