### PR TITLE
feat(cspp): Now have CSPP_BASE_URL plumbed

### DIFF
--- a/cspp/main.go
+++ b/cspp/main.go
@@ -24,6 +24,7 @@ func init() {
 
 	viper.SetDefault("port", "8080")
 	viper.SetDefault("data_dir", "data")
+	viper.SetDefault("base_url", "")
 	viper.BindEnv("port", "CSPP_PORT")
 	viper.BindEnv("data_dir", "CSPP_DATA_DIR")
 
@@ -58,6 +59,7 @@ func init() {
 	viper.BindEnv("processed_dir", "CSPP_PROCESSED_DIR")
 	viper.BindEnv("uploads_dir", "CSPP_UPLOADS_DIR")
 	viper.BindEnv("credentials_dir", "CSPP_CREDENTIALS_DIR")
+	viper.BindEnv("base_url", "CSPP_BASE_URL")
 
 	setupDirectory(viper.GetString("data_dir"))
 	setupDirectory(viper.GetString("discard_dir"))
@@ -109,5 +111,4 @@ func main() {
 
 	// Block and wait for a signal to exit
 	<-done
-
 }

--- a/cspp/slack_sender.go
+++ b/cspp/slack_sender.go
@@ -87,17 +87,21 @@ func handleNewFile(filePath string) {
 func sendKeyInDM(slackId string, key string) error {
 	log.Debugln("(sendKeyInDM) slackId", slackId, "key", key)
 	slack_token := viper.GetString("slack_token")
+	base_url := viper.GetString("base_url")
+	if base_url == "" {
+		base_url = "<service address>"
+	}
 	api := slack.New(slack_token)
-	msg := "Your CSPP API key is:  `" + key + "`" + ". Please keep it safe and do not share it with anyone. "
-	msg += "In most cases, you can use your key and the entire CSPP service via something like the following command:\n"
-	cmd := `curl -X POST \
-  -F "image=@/path/to/file" \
-  -F "caption=String you want to with the picture"  \
-  -H "X-API-KEY: $API_KEY" \
- <service URI>"`
+	msg := "You are on your way to :poop:posting!\n"
+	msg += "Your <https://github.com/stahnma/mandatoryFun/tree/main/cspp|CSPP> API key is:  `" + key + "`" + ". Please keep it safe and do not share it with anyone. "
+	msg += "In most cases, you can use your key with the entire CSPP service via something like the following command:\n"
+	cmd := "curl -X POST \\\n "
+	cmd += "-F \"image=@/path/to/file\" \\\n "
+	cmd += "-F \"caption=String you want to with the picture\" \\\n "
+	cmd += "-H \"X-API-KEY: $API_KEY\" \\\n "
+	cmd += base_url + "/upload" + "\n"
 	msg += "```" + cmd + "```"
-	// TODO add the service URI to the message
-	msg += "\n See /usage for more details."
+	msg += "\n See " + base_url + "/usage for more details."
 
 	_, _, err := api.PostMessage(slackId,
 		slack.MsgOptionText(msg, false),


### PR DESCRIPTION
Previously the application had no knowledge of where it was running or how so
it couldn't send canonical URIs to a user. Now we read from an ENV var to do
that. The var is CSPP_BASE_URL. IF that env var is not set, it falls back to
just using relaitve links.

Fixes #41