### PR TITLE
chore:(zoom-notifier) Add link into message sent to slack

### DIFF
--- a/zoom-notifier/main.go
+++ b/zoom-notifier/main.go
@@ -128,6 +128,8 @@ func processWebHook(c *gin.Context) {
 	}
 
 	msg := setMessageSuffix(jresp)
+	// create a link for the zoom meeting in the message
+	msg = msg + " [Zoom Meeting](https://zoom.us/j/" + jresp.Payload.Object.ID + ")"
 	dispatchMessage(msg)
 }
 


### PR DESCRIPTION
Previously, the slack message didn't like to the zoom. It now does. It's a
small quality of life helper.