### PR TITLE
Clarify token usage, update dependencies, and clean up

### DIFF
--- a/slack-emoji-grabber/.gitignore
+++ b/slack-emoji-grabber/.gitignore
@@ -1,2 +1,3 @@
 emojis
 slack_emoji_grabber
+.DS_Store

--- a/slack-emoji-grabber/Makefile
+++ b/slack-emoji-grabber/Makefile
@@ -4,9 +4,6 @@
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-setup: ## Install nlopes/slack
-	go get -u github.com/nlopes/slack
-
 fmt: ## Format all code
 	go fmt *.go
 

--- a/slack-emoji-grabber/README.md
+++ b/slack-emoji-grabber/README.md
@@ -4,10 +4,6 @@ Do you ever wish you could grab the emojis from one slack team and keep them? Ma
 
 # Setup
 
-You need one module that isn't in the stdlib.
-
-`go get -u github.com/nlopes/slack`
-
 You can also simply run `make setup`
 
 # Build
@@ -19,10 +15,14 @@ or run
 `make`
 
 # Configure
-To run the `slack_emoji_grabber` you need your `SLACK_TOKEN` environment variable set. If you don't have it set, it won't work.
+To run the `slack_emoji_grabber`, you need to set your **Slack Bot User OAuth Token** as `SLACK_TOKEN` in an environment variable set. The Slack Bot User OAuth Token can be found under "OAuth & Permissions" in Slack API: Applications settings under a configured & connected Slack Application for the workspace. 
+
+Example: `export SLACK_TOKEN="xoxb-1234567890-0987654321-AbCdEfGhIjKlMnOpQrStUvWxYz"`
+
 
 # Run
 `./slack_emoji_grabber`
 
 # License
 MIT
+

--- a/slack-emoji-grabber/go.mod
+++ b/slack-emoji-grabber/go.mod
@@ -1,6 +1,6 @@
 module github.com/stahnma/slack_emoji_grabber
 
-go 1.21.5
+go 1.21
 
 require github.com/slack-go/slack v0.12.3
 


### PR DESCRIPTION
Added clarification on which token to use for the emoji grabber to avoid confusion.
Updated go.mod and removed unused dependencies with `go mod tidy`.
Added `.DS_Store` to `.gitignore` for file management on macOS.
Removed outdated reference to the `nlopes/slack` module, as it's no longer used.