### PR TITLE
Update Slack detection approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mando Fun
 
 This is the collection tools, daemons, libraries and binaries for collaborating
-with your collegues across the internet. 
+with your colleagues across the internet. 
 
 The primary goal is to be things that are enjoyable to use, but ultimately have
 some utility in terms of helping people accomplish something -- even if that

--- a/hubot-modules/hubot-message-aggregator/package-lock.json
+++ b/hubot-modules/hubot-message-aggregator/package-lock.json
@@ -460,6 +460,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1200,6 +1201,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/hubot-modules/hubot-message-aggregator/src/aggregator.js
+++ b/hubot-modules/hubot-message-aggregator/src/aggregator.js
@@ -52,6 +52,15 @@ const handleReaction = (res, robot) => {
     handleReactionWithChannelId(res, robot, targetChannel, aggregatorPattern, regexFlags);
 };
 
+function isSlackAdapter(robot) {
+    const adapterName = robot.adapterName != null
+        ? robot.adapterName
+        : robot.adapter && robot.adapter.name != null
+        ? robot.adapter.name
+        : '';
+    return /slack/i.test(adapterName);
+}
+
 function handleReactionWithChannelId(res, robot, channelId, aggregatorPattern, regexFlags) {
     const message = res.message;
     const reactionRegex = new RegExp(aggregatorPattern, regexFlags);
@@ -182,7 +191,7 @@ function findChannelIdByName(robot, channelName) {
 }
 
 module.exports = (robot) => {
-    if (robot.adapterName !== 'slack') {
+    if (!isSlackAdapter(robot)) {
         return;
     }
 

--- a/hubot-modules/hubot-message-aggregator/test/aggregation-module.test.js
+++ b/hubot-modules/hubot-message-aggregator/test/aggregation-module.test.js
@@ -11,6 +11,7 @@ const {
     findChannelIdByName,
     fetchMessagePermalink
 } = aggregator;
+const isSlackAdapter = aggregator.__get__('isSlackAdapter');
 
 describe('reaction-aggregator module exports', () => {
     let robot;
@@ -573,6 +574,27 @@ describe('reaction-aggregator module exports', () => {
         });
     });
 
+    describe('isSlackAdapter', () => {
+        it('matches adapterName values containing slack', () => {
+            expect(isSlackAdapter({
+                adapterName: '@hubot-friends/hubot-slack'
+            })).to.be.true;
+        });
+
+        it('falls back to robot.adapter.name when adapterName is unset', () => {
+            expect(isSlackAdapter({
+                adapter: { name: 'SlackBot' }
+            })).to.be.true;
+        });
+
+        it('returns false when neither adapter value is slack', () => {
+            expect(isSlackAdapter({
+                adapterName: 'shell',
+                adapter: { name: 'discord' }
+            })).to.be.false;
+        });
+    });
+
     describe('module initialization', () => {
         it('does not register listener for non-slack adapter', () => {
             const initRobot = {
@@ -586,6 +608,28 @@ describe('reaction-aggregator module exports', () => {
         it('registers hearReaction for slack adapter', () => {
             const initRobot = {
                 adapterName: 'slack',
+                hearReaction: sinon.spy(),
+                logger: { error: sinon.spy(), info: sinon.spy() },
+                brain: { data: {} }
+            };
+            aggregator(initRobot);
+            expect(initRobot.hearReaction.calledOnce).to.be.true;
+        });
+
+        it('registers hearReaction for adapter names containing slack', () => {
+            const initRobot = {
+                adapterName: '@hubot-friends/hubot-slack',
+                hearReaction: sinon.spy(),
+                logger: { error: sinon.spy(), info: sinon.spy() },
+                brain: { data: {} }
+            };
+            aggregator(initRobot);
+            expect(initRobot.hearReaction.calledOnce).to.be.true;
+        });
+
+        it('registers hearReaction when robot.adapter.name contains slack', () => {
+            const initRobot = {
+                adapter: { name: 'Slack Adapter' },
                 hearReaction: sinon.spy(),
                 logger: { error: sinon.spy(), info: sinon.spy() },
                 brain: { data: {} }

--- a/hubot-modules/hubot-slacklogs/src/slacklogs.js
+++ b/hubot-modules/hubot-slacklogs/src/slacklogs.js
@@ -33,6 +33,18 @@ const slackClient = slackToken ? new WebClient(slackToken) : null;
 // In-memory cache for room name/type
 const roomCache = new Map();
 
+function getAdapterName(robot) {
+  return robot.adapterName != null
+    ? robot.adapterName
+    : robot.adapter && robot.adapter.name != null
+    ? robot.adapter.name
+    : '';
+}
+
+function isSlackAdapter(robot) {
+  return /slack/i.test(getAdapterName(robot));
+}
+
 function getSlackRoomType(roomId) {
   if (!roomId || typeof roomId !== 'string') return 'unknown';
   if (roomId.startsWith('C')) return 'public_channel';
@@ -74,8 +86,9 @@ async function getRoomInfo(roomId) {
 }
 
 module.exports = (robot) => {
-  if (robot.adapterName !== 'slack') {
-    console.log(`[hubot-logger] Adapter is '${robot.adapterName}', skipping Slack-specific logging.`);
+  const adapterName = getAdapterName(robot);
+  if (!isSlackAdapter(robot)) {
+    console.log(`[hubot-logger] Adapter is '${adapterName}', skipping Slack-specific logging.`);
     return;
   }
 
@@ -113,4 +126,3 @@ module.exports = (robot) => {
     }
   });
 };
-

--- a/hubot-modules/hubot-wisdom/src/wisdom.js
+++ b/hubot-modules/hubot-wisdom/src/wisdom.js
@@ -17,6 +17,15 @@ const {
   WebClient
 } = require('@slack/web-api');
 
+function isSlackAdapter(robot) {
+  const adapterName = robot.adapterName != null
+    ? robot.adapterName
+    : robot.adapter && robot.adapter.name != null
+    ? robot.adapter.name
+    : '';
+  return /slack/i.test(adapterName);
+}
+
 module.exports = (robot) => {
 
   // Listening for quotes and storing them
@@ -41,7 +50,7 @@ module.exports = (robot) => {
     });
 
     // Check if the bot is running in Slack
-    if(robot.adapterName === 'slack') {
+    if(isSlackAdapter(robot)) {
       const slackMessage = msg.message.rawMessage;
 
       if(slackMessage && slackMessage.ts && slackMessage.channel) {


### PR DESCRIPTION
**tl;dr** Upgraded to Hubot v14 + supported Slack adapter, the `adapterName` value changed. Need this to keep Slack detection working.


---

This pull request refactors how the codebase detects and handles Slack adapters across multiple Hubot modules. It introduces a more robust and flexible `isSlackAdapter` utility to check for Slack adapters, improving compatibility with various adapter names and reducing hardcoded checks. The update also includes new and expanded tests to ensure correct behavior. Additionally, there are minor documentation and manifest improvements.

**Slack Adapter Detection Refactor:**

* Added a flexible `isSlackAdapter` function in `hubot-message-aggregator`, `hubot-slacklogs`, and `hubot-wisdom` to detect Slack adapters by matching various possible adapter names, replacing previous strict equality checks. [[1]](diffhunk://#diff-11bb1b46b7e02a8fc37173bb36be08e61da31a8fd84b4179736dc18b924043c8R55-R63) [[2]](diffhunk://#diff-139a70da894ca1026c0083f8c36fea4154a337b66cd176e799cb5513790962e0R36-R47) [[3]](diffhunk://#diff-63d258af9c5932cfc146d8064089195e4dbbb30e1aba0b861bfe1ae5b6868bb1R20-R28)
* Updated initialization logic in `hubot-message-aggregator`, `hubot-slacklogs`, and `hubot-wisdom` to use the new `isSlackAdapter` function, ensuring Slack-specific logic only runs when appropriate. [[1]](diffhunk://#diff-11bb1b46b7e02a8fc37173bb36be08e61da31a8fd84b4179736dc18b924043c8L185-R194) [[2]](diffhunk://#diff-139a70da894ca1026c0083f8c36fea4154a337b66cd176e799cb5513790962e0L77-R91) [[3]](diffhunk://#diff-63d258af9c5932cfc146d8064089195e4dbbb30e1aba0b861bfe1ae5b6868bb1L44-R53)

**Testing Improvements:**

* Added comprehensive unit tests for `isSlackAdapter` and initialization logic in `hubot-message-aggregator/test/aggregation-module.test.js` to verify correct behavior for various adapter name scenarios. [[1]](diffhunk://#diff-b682b205c9a7c3482876f604987aea213d84e74f578521af0c77e751c00a5f9fR14) [[2]](diffhunk://#diff-b682b205c9a7c3482876f604987aea213d84e74f578521af0c77e751c00a5f9fR577-R597) [[3]](diffhunk://#diff-b682b205c9a7c3482876f604987aea213d84e74f578521af0c77e751c00a5f9fR619-R640)

**Dependency and Manifest Updates:**

* Marked `acorn` and `eslint` as peer dependencies in `hubot-message-aggregator/package-lock.json` for improved dependency management. [[1]](diffhunk://#diff-685fe97677b1b36e5870940d2711edae0e0648d8c696e9c7c046df51d60f6f2aR427) [[2]](diffhunk://#diff-685fe97677b1b36e5870940d2711edae0e0648d8c696e9c7c046df51d60f6f2aR968)
* Updated `.flox/env/manifest.toml` to use `schema-version` instead of `version` for manifest compatibility.

**Documentation:**

* Fixed a minor typo in `README.md` ("collegues" → "colleagues").